### PR TITLE
Bug fixes, peak volume meter, MouseWheel controls volume slider

### DIFF
--- a/App.config
+++ b/App.config
@@ -8,7 +8,7 @@
     <userSettings>
         <RightClickVolume.Properties.Settings>
             <setting name="LaunchOnStartup" serializeAs="String">
-                <value>False</value>
+                <value>True</value>
             </setting>
             <setting name="Hotkey_Alt" serializeAs="String">
                 <value>True</value>

--- a/App.config
+++ b/App.config
@@ -25,6 +25,9 @@
             <setting name="IsFirstRunEver" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="ShowPeakVolumeBar" serializeAs="String">
+                <value>True</value>
+            </setting>
         </RightClickVolume.Properties.Settings>
     </userSettings>
 </configuration>

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -4,8 +4,8 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media.Imaging;
 using Hardcodet.Wpf.TaskbarNotification;
-using RightClickVolume.Properties;
 using RightClickVolume.Managers;
+using RightClickVolume.Properties;
 
 
 namespace RightClickVolume;
@@ -119,7 +119,7 @@ public partial class App : Application
 
     void SettingsMenuItem_Click(object sender, RoutedEventArgs e) => OpenSettingsWindow();
 
-    private void OpenLink(object sender, RoutedEventArgs e)
+    void OpenLink(object sender, RoutedEventArgs e)
     {
         string url = "https://github.com/BitSwapper";
 

--- a/Converters/BooleanToVisibilityConverter.cs
+++ b/Converters/BooleanToVisibilityConverter.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace RightClickVolume;
+
+[ValueConversion(typeof(bool), typeof(Visibility))]
+public class BooleanToVisibilityConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        bool boolValue = false;
+        if(value is bool)
+        {
+            boolValue = (bool)value;
+        }
+        return boolValue ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if(value is Visibility visibilityValue)
+        {
+            return visibilityValue == Visibility.Visible;
+        }
+        return false;
+    }
+}

--- a/Native/WindowsHooks.cs
+++ b/Native/WindowsHooks.cs
@@ -9,17 +9,17 @@ public class WindowsHooks
     #region Win32 API Declarations
 
     [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
-    private static extern IntPtr SetWindowsHookEx(int idHook, HookProc lpfn, IntPtr hMod, uint dwThreadId);
+    static extern IntPtr SetWindowsHookEx(int idHook, HookProc lpfn, IntPtr hMod, uint dwThreadId);
 
     [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool UnhookWindowsHookEx(IntPtr hhk);
+    static extern bool UnhookWindowsHookEx(IntPtr hhk);
 
     [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
-    private static extern IntPtr CallNextHookEx(IntPtr hhk, int nCode, IntPtr wParam, IntPtr lParam);
+    static extern IntPtr CallNextHookEx(IntPtr hhk, int nCode, IntPtr wParam, IntPtr lParam);
 
     [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
-    private static extern IntPtr GetModuleHandle(string lpModuleName);
+    static extern IntPtr GetModuleHandle(string lpModuleName);
 
     [DllImport("user32.dll")]
     public static extern IntPtr WindowFromPoint(POINT point);
@@ -27,18 +27,18 @@ public class WindowsHooks
     [DllImport("user32.dll")]
     public static extern bool GetCursorPos(out POINT lpPoint);
 
-    private const int WH_MOUSE_LL = 14;
-    private const int WM_RBUTTONDOWN = 0x0204;
-    private const int WM_RBUTTONUP = 0x0205;
+    const int WH_MOUSE_LL = 14;
+    const int WM_RBUTTONDOWN = 0x0204;
+    const int WM_RBUTTONUP = 0x0205;
 
-    private delegate IntPtr HookProc(int nCode, IntPtr wParam, IntPtr lParam);
+    delegate IntPtr HookProc(int nCode, IntPtr wParam, IntPtr lParam);
 
     #endregion
 
     #region Hook Implementation
 
-    private IntPtr mouseHookHandle = IntPtr.Zero;
-    private HookProc mouseProc;
+    IntPtr mouseHookHandle = IntPtr.Zero;
+    HookProc mouseProc;
     public event EventHandler<MouseHookEventArgs> RightMouseClick;
 
     public WindowsHooks() => mouseProc = MouseHookCallback;
@@ -71,7 +71,7 @@ public class WindowsHooks
     }
 
 
-    private IntPtr MouseHookCallback(int nCode, IntPtr wParam, IntPtr lParam)
+    IntPtr MouseHookCallback(int nCode, IntPtr wParam, IntPtr lParam)
     {
         if(nCode >= 0)
         {
@@ -99,7 +99,7 @@ public class WindowsHooks
     #region Native Structures
 
     [StructLayout(LayoutKind.Sequential)]
-    private struct MSLLHOOKSTRUCT
+    struct MSLLHOOKSTRUCT
     {
         public POINT pt;
         public uint mouseData;

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -15,7 +15,7 @@ namespace RightClickVolume.Properties {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.13.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
-        private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
+     static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
         
         public static Settings Default {
             get {

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -15,7 +15,7 @@ namespace RightClickVolume.Properties {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.13.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
-     static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
+        private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
         
         public static Settings Default {
             get {
@@ -103,6 +103,18 @@ namespace RightClickVolume.Properties {
             }
             set {
                 this["IsFirstRunEver"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool ShowPeakVolumeBar {
+            get {
+                return ((bool)(this["ShowPeakVolumeBar"]));
+            }
+            set {
+                this["ShowPeakVolumeBar"] = value;
             }
         }
     }

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -15,7 +15,7 @@ namespace RightClickVolume.Properties {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.13.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
-        private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
+        static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
         
         public static Settings Default {
             get {

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -15,7 +15,7 @@ namespace RightClickVolume.Properties {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.13.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
-        static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
+        private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
         
         public static Settings Default {
             get {
@@ -25,7 +25,7 @@ namespace RightClickVolume.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
         public bool LaunchOnStartup {
             get {
                 return ((bool)(this["LaunchOnStartup"]));

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -3,7 +3,7 @@
   <Profiles />
   <Settings>
     <Setting Name="LaunchOnStartup" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">False</Value>
+      <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="ManualMappings" Type="System.Collections.Specialized.StringCollection" Scope="User">
       <Value Profile="(Default)" />

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -23,5 +23,8 @@
     <Setting Name="IsFirstRunEver" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="ShowPeakVolumeBar" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Windows/ProcessSelectorDialog.xaml.cs
+++ b/Windows/ProcessSelectorDialog.xaml.cs
@@ -16,7 +16,7 @@ public partial class ProcessSelectorDialog : Window
         LoadProcesses();
     }
 
-    private void LoadProcesses()
+    void LoadProcesses()
     {
         try
         {
@@ -29,7 +29,7 @@ public partial class ProcessSelectorDialog : Window
         }
     }
 
-    private void SelectProcessAndClose()
+    void SelectProcessAndClose()
     {
         var selectedItem = ProcessListView.SelectedItem as Process;
         if(selectedItem != null)
@@ -41,9 +41,9 @@ public partial class ProcessSelectorDialog : Window
             MessageBox.Show("Please select a process from the list.", "No Selection", MessageBoxButton.OK, MessageBoxImage.Information);
     }
 
-    private void SelectButton_Click(object sender, RoutedEventArgs e) => SelectProcessAndClose();
+    void SelectButton_Click(object sender, RoutedEventArgs e) => SelectProcessAndClose();
 
-    private void ProcessListView_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+    void ProcessListView_MouseDoubleClick(object sender, MouseButtonEventArgs e)
     {
         if(ProcessListView.SelectedItem != null)
             SelectProcessAndClose();

--- a/Windows/SettingsWindow.xaml
+++ b/Windows/SettingsWindow.xaml
@@ -21,13 +21,9 @@
             <!-- Buttons -->
         </Grid.RowDefinitions>
 
-        <!-- Launch on Startup -->
-        <CheckBox x:Name="LaunchOnStartupCheckBox" Grid.Row="0" Margin="5"
-                  Content="Launch application when Windows starts"/>
+        <CheckBox x:Name="LaunchOnStartupCheckBox" Grid.Row="0" Margin="5" Content="Launch application when Windows starts"/>
 
-        <!-- Show Peak Volume Bar CheckBox -->
-        <CheckBox x:Name="ShowPeakVolumeBarCheckBox" Grid.Row="1" Margin="5"
-                  Content="Show peak volume meter"/>
+        <CheckBox x:Name="ShowPeakVolumeBarCheckBox" Grid.Row="1" Margin="5" Content="Show peak volume meter"/>
 
         <!-- Hotkey Settings -->
         <GroupBox Header="Activation Hotkey (Modifiers + Right Mouse Click)" Grid.Row="2" Margin="5">

--- a/Windows/SettingsWindow.xaml
+++ b/Windows/SettingsWindow.xaml
@@ -27,7 +27,7 @@
 
         <!-- Show Peak Volume Bar CheckBox -->
         <CheckBox x:Name="ShowPeakVolumeBarCheckBox" Grid.Row="1" Margin="5"
-                  Content="Show peak volume meter bar in volume control window"/>
+                  Content="Show peak volume meter"/>
 
         <!-- Hotkey Settings -->
         <GroupBox Header="Activation Hotkey (Modifiers + Right Mouse Click)" Grid.Row="2" Margin="5">

--- a/Windows/SettingsWindow.xaml
+++ b/Windows/SettingsWindow.xaml
@@ -5,12 +5,14 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:RightClickVolume"
         mc:Ignorable="d"
-        Title="Settings - RightClick Volume" Height="550" Width="500"
-        WindowStartupLocation="CenterScreen" ResizeMode="NoResize" ShowInTaskbar="False">
+        Title="Settings - RightClick Volume" Height="580" Width="500"
+    WindowStartupLocation="CenterScreen" ResizeMode="NoResize" ShowInTaskbar="False">
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <!-- Startup -->
+            <RowDefinition Height="Auto"/>
+            <!-- UI Settings (New Row for Peak Volume Bar) -->
             <RowDefinition Height="Auto"/>
             <!-- Hotkey -->
             <RowDefinition Height="*"/>
@@ -23,8 +25,12 @@
         <CheckBox x:Name="LaunchOnStartupCheckBox" Grid.Row="0" Margin="5"
                   Content="Launch application when Windows starts"/>
 
+        <!-- Show Peak Volume Bar CheckBox -->
+        <CheckBox x:Name="ShowPeakVolumeBarCheckBox" Grid.Row="1" Margin="5"
+                  Content="Show peak volume meter bar in volume control window"/>
+
         <!-- Hotkey Settings -->
-        <GroupBox Header="Activation Hotkey (Modifiers + Right Mouse Click)" Grid.Row="1" Margin="5">
+        <GroupBox Header="Activation Hotkey (Modifiers + Right Mouse Click)" Grid.Row="2" Margin="5">
             <StackPanel Margin="5">
                 <TextBlock Text="Select the modifier keys required:" Margin="0,0,0,5"/>
                 <CheckBox x:Name="HotkeyCtrlCheckBox" Content="Ctrl" Margin="5,2"/>
@@ -37,7 +43,7 @@
         </GroupBox>
 
         <!-- Manual Mappings -->
-        <GroupBox Header="Manual UIA Name -> Process Mappings" Grid.Row="2" Margin="5">
+        <GroupBox Header="Manual UIA Name -> Process Mappings" Grid.Row="3" Margin="5">
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="*"/>
@@ -46,7 +52,6 @@
                 <ListView x:Name="MappingsListView" Grid.Row="0" Margin="5" ItemsSource="{Binding Mappings}" SelectionMode="Single">
                     <ListView.View>
                         <GridView>
-                            <!-- Adjust Widths slightly if needed due to added GroupBox -->
                             <GridViewColumn Header="UIA Name (Key)" Width="190" DisplayMemberBinding="{Binding UiaName}"/>
                             <GridViewColumn Header="Target Process List" Width="230" DisplayMemberBinding="{Binding ProcessNameList}"/>
                         </GridView>
@@ -60,7 +65,7 @@
         </GroupBox>
 
         <!-- Save/Close Buttons -->
-        <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="5">
+        <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right" Margin="5">
             <Button Content="Save and Close" Width="100" Margin="5,0" Click="SaveButton_Click" IsDefault="True"/>
             <Button Content="Cancel" Width="80" Margin="5,0" Click="CancelButton_Click" IsCancel="True"/>
         </StackPanel>

--- a/Windows/SettingsWindow.xaml.cs
+++ b/Windows/SettingsWindow.xaml.cs
@@ -25,6 +25,7 @@ public partial class SettingsWindow : Window
     void LoadSettings()
     {
         LaunchOnStartupCheckBox.IsChecked = Settings.Default.LaunchOnStartup;
+        ShowPeakVolumeBarCheckBox.IsChecked = Settings.Default.ShowPeakVolumeBar;
         LoadHotkeySettings();
         LoadMappings();
     }
@@ -121,6 +122,7 @@ public partial class SettingsWindow : Window
     void SaveSettings()
     {
         SaveStartupSetting();
+        Settings.Default.ShowPeakVolumeBar = ShowPeakVolumeBarCheckBox.IsChecked ?? false;
         SaveHotkeySettings();
         SaveMappings();
         TrySaveSettingsToStorage();

--- a/Windows/VolumeKnob.xaml
+++ b/Windows/VolumeKnob.xaml
@@ -197,47 +197,85 @@
             </Setter>
         </Style>
 
+        <!-- Style for the Peak Volume Meter (ProgressBar) -->
+        <Style x:Key="PeakMeterStyle" TargetType="ProgressBar">
+            <Setter Property="Orientation" Value="Vertical"/>
+            <Setter Property="Width" Value="10"/>
+            <!-- Adjust width as needed -->
+            <Setter Property="Background" Value="#FF383838"/>
+            <!-- Background of the meter track -->
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Foreground">
+                <!-- This is the fill of the progress bar -->
+                <Setter.Value>
+                    <LinearGradientBrush StartPoint="0.5,1" EndPoint="0.5,0">
+                        <!-- Fills from bottom (green) to top (red) -->
+                        <GradientStop Color="GreenYellow" Offset="0.0" />
+                        <GradientStop Color="#A2FF00" Offset="0.4" />
+                        <!-- Brighter Green -->
+                        <GradientStop Color="Yellow" Offset="0.75" />
+                        <GradientStop Color="OrangeRed" Offset="0.9" />
+                        <GradientStop Color="Red" Offset="1.0" />
+                    </LinearGradientBrush>
+                </Setter.Value>
+            </Setter>
+            <!-- Optional: Apply a simple template for rounded corners if default isn't sufficient -->
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ProgressBar">
+                        <Border x:Name="TemplateRoot"
+                                CornerRadius="4"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}">
+                            <Grid>
+                                <Rectangle x:Name="PART_Track" />
+                                <Rectangle x:Name="PART_Indicator"
+                                           Fill="{TemplateBinding Foreground}"
+                                           HorizontalAlignment="Stretch"
+                                           VerticalAlignment="Bottom" />
+                                <!-- WPF's ProgressBar logic for Orientation="Vertical" 
+                                     will adjust PART_Indicator's Height based on Value -->
+                            </Grid>
+                        </Border>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+            <Style.Triggers>
+                <Trigger Property="IsEnabled" Value="False">
+                    <Setter Property="Opacity" Value="0.4"/>
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+
     </Window.Resources>
     <!-- ========================== -->
     <!--       RESOURCES END        -->
     <!-- ========================== -->
 
-
-    <!-- ============================================================ -->
-    <!--  !!! THIS BORDER IS THE **ONLY** DIRECT CHILD OF WINDOW !!!  -->
-    <!--  It is implicitly assigned to the Window.Content property    -->
-    <!-- ============================================================ -->
-    <!-- ============================================================ -->
-    <!--  !!! THIS BORDER IS THE **ONLY** DIRECT CHILD OF WINDOW !!!  -->
-    <!-- ============================================================ -->
     <Border CornerRadius="10" BorderThickness="0">
         <Border.Background>
-            <!-- Replaced LinearGradientBrush with RadialGradientBrush -->
             <RadialGradientBrush GradientOrigin="0.5, 0.5" Center="0.5,0.5" RadiusX="1" RadiusY="2">
                 <GradientStop Color="#FF444444" Offset="0.0" />
-                <!-- Slightly lighter grey at the origin (top-center) -->
                 <GradientStop Color="#BB2A2A2A" Offset="1.0" />
-                <!-- Darker grey towards the edges -->
             </RadialGradientBrush>
         </Border.Background>
         <Border.Effect>
-            <!-- Existing DropShadowEffect -->
             <DropShadowEffect ShadowDepth="3" Direction="315" Color="Black" Opacity="0.4" BlurRadius="8"/>
         </Border.Effect>
 
-        <!-- Main Content Grid (everything visual goes inside this Grid) -->
+        <!-- Main Content Grid -->
         <Grid Margin="6">
-            <!-- ... (rest of the Grid content remains the same) ... -->
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <!-- Row 0: Buttons -->
                 <RowDefinition Height="Auto" />
                 <!-- Row 1: Current Volume Text -->
-                <RowDefinition Height="33*"    />
-                <RowDefinition Height="146*"/>
-                <!-- Row 2: Slider -->
+                <RowDefinition Height="33*"  />
+                <!-- Row 2: Slider Area (Part 1) -->
+                <RowDefinition Height="146*" />
+                <!-- Row 2: Slider Area (Part 2) -->
                 <RowDefinition Height="Auto" />
-
                 <!-- Row 3: App Name -->
             </Grid.RowDefinitions>
 
@@ -254,10 +292,33 @@
             <!-- Row 1: Current Volume Text -->
             <TextBlock x:Name="TextCurVol" Grid.Row="1" Text="{Binding CurVol, FallbackValue=50, TargetNullValue=--}" Foreground="#EFEFEF" FontWeight="DemiBold" FontSize="20" TextAlignment="Center" Margin="0,0,0,5"/>
 
-            <!-- Row 2: Volume Slider -->
-            <Slider x:Name="VolumeSlider" Grid.Row="2" Orientation="Vertical" Minimum="0" Maximum="100" Value="{Binding Volume, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Center" Margin="0,8,0,8" IsDirectionReversed="False" ValueChanged="VolumeSlider_ValueChanged" Style="{StaticResource VolumeSliderStyle}" Grid.RowSpan="2"/>
+            <!-- Row 2 & 3 (spanned): Volume Slider and Peak Meter -->
+            <StackPanel Grid.Row="2" Grid.RowSpan="2" Orientation="Horizontal"
+                        HorizontalAlignment="Center" VerticalAlignment="Stretch" Margin="0,8,0,8">
 
-            <!-- Row 3: App Name Text -->
+                <!-- Volume Control Slider -->
+                <Slider x:Name="VolumeSlider"
+                        Orientation="Vertical"
+                        Minimum="0" Maximum="100"
+                        Value="{Binding Volume, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                        IsDirectionReversed="False"
+                    ValueChanged="VolumeSlider_ValueChanged"
+                        Style="{StaticResource VolumeSliderStyle}"
+                        VerticalAlignment="Stretch"
+                        Margin="0,0,5,0"/>
+                    <!-- Margin to space it from peak meter -->
+
+                    <!-- Peak Volume Meter -->
+                <ProgressBar x:Name="PeakVolumeMeter"
+             Orientation="Vertical"
+             Width="10"
+             Minimum="0" Maximum="100"
+             Value="{Binding PeakLevel, Mode=OneWay, FallbackValue=0}"
+             VerticalAlignment="Stretch"
+             IsEnabled="{Binding Path=IsEnabled, ElementName=VolumeSlider}"/>
+            </StackPanel>
+
+            <!-- Row 4 (was Row 3): App Name Text -->
             <TextBlock x:Name="AppNameTextBlock" Grid.Row="4" Text="{Binding AppName, FallbackValue=Application Name, TargetNullValue=Unknown App}" Foreground="#DDDDDD" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" TextAlignment="Center" FontSize="11" Margin="0,8,0,0"/>
         </Grid>
         <!-- End Main Content Grid -->

--- a/Windows/VolumeKnob.xaml
+++ b/Windows/VolumeKnob.xaml
@@ -17,17 +17,14 @@
         AllowsTransparency="True"
         Background="Transparent"
         Focusable="True"
-        WindowStartupLocation="Manual">
+        WindowStartupLocation="Manual"
+        MouseWheel="VolumeKnob_MouseWheel">
 
-    <!-- ========================== -->
-    <!--      RESOURCES START       -->
-    <!-- ========================== -->
     <Window.Resources>
-
-        <local:ValueToHeightConverter x:Key="ValueToHeightConverter"/>
         <local:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+        <local:ValueToHeightConverter x:Key="ValueToHeightConverter"/>
 
-        <!-- Base Button Style -->
+        <!-- Styles omitted for brevity, they remain the same -->
         <Style x:Key="ModernButtonStyle" TargetType="Button">
             <Setter Property="Width" Value="24"/>
             <Setter Property="Height" Value="24"/>
@@ -64,12 +61,9 @@
                 </Setter.Value>
             </Setter>
         </Style>
-
-        <!-- Mute Button Style -->
         <Style x:Key="MuteButtonStyle" TargetType="Button" BasedOn="{StaticResource ModernButtonStyle}">
             <Setter Property="FontFamily" Value="Segoe UI Emoji"/>
             <Setter Property="FontSize" Value="10"/>
-            <!-- Background/Foreground set dynamically in code-behind -->
             <Style.Triggers>
                 <Trigger Property="IsMouseOver" Value="True">
                     <Setter Property="Background" Value="#5A5A5A"/>
@@ -81,8 +75,6 @@
                 </Trigger>
             </Style.Triggers>
         </Style>
-
-        <!-- Slider Thumb Style -->
         <Style x:Key="VolumeSliderThumbStyle" TargetType="{x:Type Thumb}">
             <Setter Property="SnapsToDevicePixels" Value="True"/>
             <Setter Property="OverridesDefaultStyle" Value="True"/>
@@ -124,8 +116,6 @@
                 </Setter.Value>
             </Setter>
         </Style>
-
-        <!-- Empty RepeatButton Style for Slider Track -->
         <Style x:Key="SliderButtonStyle" TargetType="RepeatButton">
             <Setter Property="Template">
                 <Setter.Value>
@@ -135,8 +125,6 @@
                 </Setter.Value>
             </Setter>
         </Style>
-
-        <!-- Volume Slider Style -->
         <Style x:Key="VolumeSliderStyle" TargetType="{x:Type Slider}">
             <Setter Property="SnapsToDevicePixels" Value="True"/>
             <Setter Property="OverridesDefaultStyle" Value="True"/>
@@ -144,7 +132,6 @@
                 <Setter.Value>
                     <ControlTemplate TargetType="{x:Type Slider}">
                         <Grid>
-                            <!-- Track Background -->
                             <Border x:Name="TrackBackground" Width="8" CornerRadius="4" HorizontalAlignment="Center" VerticalAlignment="Stretch">
                                 <Border.Background>
                                     <LinearGradientBrush StartPoint="0.5, 0" EndPoint="0.5, 0.7">
@@ -153,8 +140,6 @@
                                     </LinearGradientBrush>
                                 </Border.Background>
                             </Border>
-
-                            <!-- Filled part of Track -->
                             <Border x:Name="PART_SelectionRange" Width="8" CornerRadius="4" HorizontalAlignment="Center" VerticalAlignment="Bottom">
                                 <Border.Height>
                                     <MultiBinding Converter="{StaticResource ValueToHeightConverter}">
@@ -169,8 +154,6 @@
                                     </LinearGradientBrush>
                                 </Border.Background>
                             </Border>
-
-                            <!-- Track Control (hosts Thumb) -->
                             <Track x:Name="PART_Track" Orientation="Vertical">
                                 <Track.Thumb>
                                     <Thumb x:Name="Thumb" Style="{StaticResource VolumeSliderThumbStyle}" />
@@ -190,22 +173,17 @@
                                 <Setter TargetName="Thumb" Property="Opacity" Value="0.4"/>
                                 <Setter TargetName="TrackBackground" Property="Opacity" Value="0.6"/>
                             </Trigger>
-                            <Trigger Property="IsMouseOver" Value="True">
-                                <!-- Optional hover effect -->
-                            </Trigger>
                         </ControlTemplate.Triggers>
                     </ControlTemplate>
                 </Setter.Value>
             </Setter>
         </Style>
 
-
     </Window.Resources>
-    <!-- ========================== -->
-    <!--       RESOURCES END        -->
-    <!-- ========================== -->
 
-    <Border CornerRadius="10" BorderThickness="0">
+    <Border CornerRadius="10" BorderThickness="0"
+            MouseLeftButtonDown="Window_MouseLeftButtonDown_Drag">
+        <!-- Changed name for clarity -->
         <Border.Background>
             <RadialGradientBrush GradientOrigin="0.5, 0.5" Center="0.5,0.5" RadiusX="1" RadiusY="2">
                 <GradientStop Color="#FF444444" Offset="0.0" />
@@ -216,7 +194,6 @@
             <DropShadowEffect ShadowDepth="3" Direction="315" Color="Black" Opacity="0.4" BlurRadius="8"/>
         </Border.Effect>
 
-        <!-- Main Content Grid -->
         <Grid Margin="6">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
@@ -224,7 +201,6 @@
                 <RowDefinition Height="33*"  />
                 <RowDefinition Height="146*" />
                 <RowDefinition Height="Auto" />
-                <!-- Row 3: App Name -->
             </Grid.RowDefinitions>
 
             <!-- Row 0: Buttons -->
@@ -238,25 +214,25 @@
             </Grid>
 
             <!-- Row 1: Current Volume Text -->
-            <TextBlock x:Name="TextCurVol" Grid.Row="1" Text="{Binding CurVol, FallbackValue=50, TargetNullValue=--}" Foreground="#EFEFEF" FontWeight="DemiBold" FontSize="20" TextAlignment="Center" Margin="0,0,0,5"/>
+            <TextBlock x:Name="TextCurVol" Grid.Row="1" Text="{Binding CurVol, FallbackValue=50, TargetNullValue=--}" Foreground="#EFEFEF" FontWeight="DemiBold" FontSize="20" TextAlignment="Center" Margin="0,0,0,5"
+                       MouseLeftButtonDown="Window_MouseLeftButtonDown_Drag"/>
+            <!-- Add handler here -->
 
             <!-- Row 2 & 3 (spanned): Volume Slider and Peak Meter -->
             <Grid Grid.Row="2" Grid.RowSpan="2"
                         HorizontalAlignment="Center" VerticalAlignment="Stretch" Margin="0,8,0,8">
 
-                <!-- Volume Control Slider -->
                 <Slider x:Name="VolumeSlider"
                         Orientation="Vertical"
                         Minimum="0" Maximum="100"
                         Value="{Binding Volume, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                         IsDirectionReversed="False"
-                    ValueChanged="VolumeSlider_ValueChanged"
+                        ValueChanged="VolumeSlider_ValueChanged"
                         Style="{StaticResource VolumeSliderStyle}"
                         VerticalAlignment="Stretch"
                         Panel.ZIndex="1"
                         Margin="0,0,0,0"/>
 
-                    <!-- Peak Volume Meter -->
                 <ProgressBar x:Name="PeakVolumeMeter"
                              BorderThickness="0"
                              Orientation="Vertical"
@@ -269,14 +245,12 @@
                              Margin="5, 2, 0, 1"
                              IsEnabled="{Binding Path=IsEnabled, ElementName=VolumeSlider}"
                              Visibility="{Binding Source={x:Static p:Settings.Default}, Path=ShowPeakVolumeBar, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}"/>
-                <!-- Modified Visibility -->
             </Grid>
 
-            <!-- Row 4 (was Row 3): App Name Text -->
-            <TextBlock x:Name="AppNameTextBlock" Grid.Row="4" Text="{Binding AppName, FallbackValue=Application Name, TargetNullValue=Unknown App}" Foreground="#DDDDDD" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" TextAlignment="Center" FontSize="11" Margin="0,8,0,0"/>
+            <!-- Row 4: App Name Text -->
+            <TextBlock x:Name="AppNameTextBlock" Grid.Row="4" Text="{Binding AppName, FallbackValue=Application Name, TargetNullValue=Unknown App}" Foreground="#DDDDDD" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" TextAlignment="Center" FontSize="11" Margin="0,8,0,0"
+                       MouseLeftButtonDown="Window_MouseLeftButtonDown_Drag"/>
+            <!-- Add handler here -->
         </Grid>
-        <!-- End Main Content Grid -->
-
     </Border>
-    <!-- End Main Container Border -->
 </Window>

--- a/Windows/VolumeKnob.xaml
+++ b/Windows/VolumeKnob.xaml
@@ -11,6 +11,7 @@
         WindowStyle="None"
         ResizeMode="NoResize"
         ShowInTaskbar="False"
+        BorderThickness="0"
         Topmost="True"
         AllowsTransparency="True"
         Background="Transparent"
@@ -24,6 +25,7 @@
 
         <!-- Converter (Ensure ValueToHeightConverter exists in the 'local' namespace) -->
         <local:ValueToHeightConverter x:Key="ValueToHeightConverter"/>
+        
 
         <!-- Base Button Style -->
         <Style x:Key="ModernButtonStyle" TargetType="Button">
@@ -293,7 +295,7 @@
             <TextBlock x:Name="TextCurVol" Grid.Row="1" Text="{Binding CurVol, FallbackValue=50, TargetNullValue=--}" Foreground="#EFEFEF" FontWeight="DemiBold" FontSize="20" TextAlignment="Center" Margin="0,0,0,5"/>
 
             <!-- Row 2 & 3 (spanned): Volume Slider and Peak Meter -->
-            <StackPanel Grid.Row="2" Grid.RowSpan="2" Orientation="Horizontal"
+            <Grid Grid.Row="2" Grid.RowSpan="2"
                         HorizontalAlignment="Center" VerticalAlignment="Stretch" Margin="0,8,0,8">
 
                 <!-- Volume Control Slider -->
@@ -305,18 +307,23 @@
                     ValueChanged="VolumeSlider_ValueChanged"
                         Style="{StaticResource VolumeSliderStyle}"
                         VerticalAlignment="Stretch"
-                        Margin="0,0,5,0"/>
+                        Panel.ZIndex="1"
+                        Margin="0,0,0,0"/>
                     <!-- Margin to space it from peak meter -->
 
                     <!-- Peak Volume Meter -->
                 <ProgressBar x:Name="PeakVolumeMeter"
+                             BorderThickness="0"
              Orientation="Vertical"
+             Foreground="#7F0A9A34"
+             Background="Transparent"             
              Width="10"
              Minimum="0" Maximum="100"
              Value="{Binding PeakLevel, Mode=OneWay, FallbackValue=0}"
              VerticalAlignment="Stretch"
              IsEnabled="{Binding Path=IsEnabled, ElementName=VolumeSlider}"/>
-            </StackPanel>
+                
+            </Grid>
 
             <!-- Row 4 (was Row 3): App Name Text -->
             <TextBlock x:Name="AppNameTextBlock" Grid.Row="4" Text="{Binding AppName, FallbackValue=Application Name, TargetNullValue=Unknown App}" Foreground="#DDDDDD" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" TextAlignment="Center" FontSize="11" Margin="0,8,0,0"/>

--- a/Windows/VolumeKnob.xaml
+++ b/Windows/VolumeKnob.xaml
@@ -4,6 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:RightClickVolume"
+        xmlns:p="clr-namespace:RightClickVolume.Properties"
         mc:Ignorable="d"
         Title="Volume Knob"
         Width="70" Height="300"
@@ -23,9 +24,8 @@
     <!-- ========================== -->
     <Window.Resources>
 
-        <!-- Converter (Ensure ValueToHeightConverter exists in the 'local' namespace) -->
         <local:ValueToHeightConverter x:Key="ValueToHeightConverter"/>
-        
+        <local:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
 
         <!-- Base Button Style -->
         <Style x:Key="ModernButtonStyle" TargetType="Button">
@@ -258,17 +258,18 @@
 
                     <!-- Peak Volume Meter -->
                 <ProgressBar x:Name="PeakVolumeMeter"
-             BorderThickness="0"
-             Orientation="Vertical"
-             Foreground="#7F0A9A34"
-             Background="Transparent"             
-             Width="10"
-             Minimum="0" Maximum="100"
-             Value="{Binding PeakLevel, Mode=OneWay, FallbackValue=0}"
-             VerticalAlignment="Stretch"
-             Margin="5, 2, 0, 1"
-             IsEnabled="{Binding Path=IsEnabled, ElementName=VolumeSlider}"/>
-             
+                             BorderThickness="0"
+                             Orientation="Vertical"
+                             Foreground="#7F0A9A34"
+                             Background="Transparent"             
+                             Width="10"
+                             Minimum="0" Maximum="100"
+                             Value="{Binding PeakLevel, Mode=OneWay, FallbackValue=0}"
+                             VerticalAlignment="Stretch"
+                             Margin="5, 2, 0, 1"
+                             IsEnabled="{Binding Path=IsEnabled, ElementName=VolumeSlider}"
+                             Visibility="{Binding Source={x:Static p:Settings.Default}, Path=ShowPeakVolumeBar, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}"/>
+                <!-- Modified Visibility -->
             </Grid>
 
             <!-- Row 4 (was Row 3): App Name Text -->

--- a/Windows/VolumeKnob.xaml
+++ b/Windows/VolumeKnob.xaml
@@ -24,7 +24,6 @@
         <local:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
         <local:ValueToHeightConverter x:Key="ValueToHeightConverter"/>
 
-        <!-- Styles omitted for brevity, they remain the same -->
         <Style x:Key="ModernButtonStyle" TargetType="Button">
             <Setter Property="Width" Value="24"/>
             <Setter Property="Height" Value="24"/>
@@ -216,7 +215,6 @@
             <!-- Row 1: Current Volume Text -->
             <TextBlock x:Name="TextCurVol" Grid.Row="1" Text="{Binding CurVol, FallbackValue=50, TargetNullValue=--}" Foreground="#EFEFEF" FontWeight="DemiBold" FontSize="20" TextAlignment="Center" Margin="0,0,0,5"
                        MouseLeftButtonDown="Window_MouseLeftButtonDown_Drag"/>
-            <!-- Add handler here -->
 
             <!-- Row 2 & 3 (spanned): Volume Slider and Peak Meter -->
             <Grid Grid.Row="2" Grid.RowSpan="2"
@@ -250,7 +248,6 @@
             <!-- Row 4: App Name Text -->
             <TextBlock x:Name="AppNameTextBlock" Grid.Row="4" Text="{Binding AppName, FallbackValue=Application Name, TargetNullValue=Unknown App}" Foreground="#DDDDDD" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" TextAlignment="Center" FontSize="11" Margin="0,8,0,0"
                        MouseLeftButtonDown="Window_MouseLeftButtonDown_Drag"/>
-            <!-- Add handler here -->
         </Grid>
     </Border>
 </Window>

--- a/Windows/VolumeKnob.xaml
+++ b/Windows/VolumeKnob.xaml
@@ -199,56 +199,6 @@
             </Setter>
         </Style>
 
-        <!-- Style for the Peak Volume Meter (ProgressBar) -->
-        <Style x:Key="PeakMeterStyle" TargetType="ProgressBar">
-            <Setter Property="Orientation" Value="Vertical"/>
-            <Setter Property="Width" Value="10"/>
-            <!-- Adjust width as needed -->
-            <Setter Property="Background" Value="#FF383838"/>
-            <!-- Background of the meter track -->
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Foreground">
-                <!-- This is the fill of the progress bar -->
-                <Setter.Value>
-                    <LinearGradientBrush StartPoint="0.5,1" EndPoint="0.5,0">
-                        <!-- Fills from bottom (green) to top (red) -->
-                        <GradientStop Color="GreenYellow" Offset="0.0" />
-                        <GradientStop Color="#A2FF00" Offset="0.4" />
-                        <!-- Brighter Green -->
-                        <GradientStop Color="Yellow" Offset="0.75" />
-                        <GradientStop Color="OrangeRed" Offset="0.9" />
-                        <GradientStop Color="Red" Offset="1.0" />
-                    </LinearGradientBrush>
-                </Setter.Value>
-            </Setter>
-            <!-- Optional: Apply a simple template for rounded corners if default isn't sufficient -->
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="ProgressBar">
-                        <Border x:Name="TemplateRoot"
-                                CornerRadius="4"
-                                Background="{TemplateBinding Background}"
-                                BorderBrush="{TemplateBinding BorderBrush}"
-                                BorderThickness="{TemplateBinding BorderThickness}">
-                            <Grid>
-                                <Rectangle x:Name="PART_Track" />
-                                <Rectangle x:Name="PART_Indicator"
-                                           Fill="{TemplateBinding Foreground}"
-                                           HorizontalAlignment="Stretch"
-                                           VerticalAlignment="Bottom" />
-                                <!-- WPF's ProgressBar logic for Orientation="Vertical" 
-                                     will adjust PART_Indicator's Height based on Value -->
-                            </Grid>
-                        </Border>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-            <Style.Triggers>
-                <Trigger Property="IsEnabled" Value="False">
-                    <Setter Property="Opacity" Value="0.4"/>
-                </Trigger>
-            </Style.Triggers>
-        </Style>
 
     </Window.Resources>
     <!-- ========================== -->
@@ -270,13 +220,9 @@
         <Grid Margin="6">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
-                <!-- Row 0: Buttons -->
                 <RowDefinition Height="Auto" />
-                <!-- Row 1: Current Volume Text -->
                 <RowDefinition Height="33*"  />
-                <!-- Row 2: Slider Area (Part 1) -->
                 <RowDefinition Height="146*" />
-                <!-- Row 2: Slider Area (Part 2) -->
                 <RowDefinition Height="Auto" />
                 <!-- Row 3: App Name -->
             </Grid.RowDefinitions>
@@ -309,11 +255,10 @@
                         VerticalAlignment="Stretch"
                         Panel.ZIndex="1"
                         Margin="0,0,0,0"/>
-                    <!-- Margin to space it from peak meter -->
 
                     <!-- Peak Volume Meter -->
                 <ProgressBar x:Name="PeakVolumeMeter"
-                             BorderThickness="0"
+             BorderThickness="0"
              Orientation="Vertical"
              Foreground="#7F0A9A34"
              Background="Transparent"             
@@ -321,8 +266,9 @@
              Minimum="0" Maximum="100"
              Value="{Binding PeakLevel, Mode=OneWay, FallbackValue=0}"
              VerticalAlignment="Stretch"
+             Margin="5, 2, 0, 1"
              IsEnabled="{Binding Path=IsEnabled, ElementName=VolumeSlider}"/>
-                
+             
             </Grid>
 
             <!-- Row 4 (was Row 3): App Name Text -->

--- a/Windows/VolumeKnob.xaml.cs
+++ b/Windows/VolumeKnob.xaml.cs
@@ -26,11 +26,11 @@ public partial class VolumeKnob : Window, INotifyPropertyChanged
     DispatcherTimer peakMeterTimer;
     float _peakLevel;
 
-    private const float PeakAttackFactor = 0.9f;
-    private const float PeakDecayFactor = 0.80f;
-    private const float BasePeakMeterScaleFactor = 140.0f;
-    private const double PeakCurvePower = 0.65;
-    private const int PeakMeterTimerInterval = 3;
+    const float PeakAttackFactor = 0.9f;
+    const float PeakDecayFactor = 0.80f;
+    const float BasePeakMeterScaleFactor = 140.0f;
+    const double PeakCurvePower = 0.65;
+    const int PeakMeterTimerInterval = 3;
 
     static readonly SolidColorBrush BG_Muted = new SolidColorBrush(Color.FromRgb(0x80, 0x30, 0x30));
     static readonly SolidColorBrush FG_Muted = Brushes.White;
@@ -132,15 +132,13 @@ public partial class VolumeKnob : Window, INotifyPropertyChanged
         Settings.Default.PropertyChanged += Settings_PropertyChanged;
     }
 
-    private void Settings_PropertyChanged(object sender, PropertyChangedEventArgs e)
+    void Settings_PropertyChanged(object sender, PropertyChangedEventArgs e)
     {
         if(e.PropertyName == nameof(Settings.Default.ShowPeakVolumeBar))
-        {
             UpdatePeakMeterTimerState();
-        }
     }
 
-    private void UpdatePeakMeterTimerState()
+    void UpdatePeakMeterTimerState()
     {
         if(peakMeterTimer == null) return;
         bool shouldTimerRun = Settings.Default.ShowPeakVolumeBar &&
@@ -164,9 +162,7 @@ public partial class VolumeKnob : Window, INotifyPropertyChanged
                 Debug.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] Peak meter timer STOPPED for {AppName} (Show: {Settings.Default.ShowPeakVolumeBar}, Visible: {this.IsVisible}, Muted: {session?.IsMuted}).");
             }
             if(!Settings.Default.ShowPeakVolumeBar || (session != null && session.IsMuted) || !this.IsVisible)
-            {
                 PeakLevel = 0;
-            }
         }
     }
 
@@ -174,9 +170,8 @@ public partial class VolumeKnob : Window, INotifyPropertyChanged
     {
         Debug.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] VolumeKnob.ShowAt: Method called for session: {(session?.DisplayName ?? "NULL SESSION")}, PID: {(session?.ProcessId.ToString() ?? "N/A")}");
         if(session == null)
-        {
             throw new ArgumentNullException(nameof(session));
-        }
+
         this.session = session;
         isUpdatingFromCode = true;
         AppName = session.DisplayName;
@@ -213,14 +208,12 @@ public partial class VolumeKnob : Window, INotifyPropertyChanged
         }
     }
 
-    private void Window_MouseLeftButtonDown_Drag(object sender, MouseButtonEventArgs e)
+    void Window_MouseLeftButtonDown_Drag(object sender, MouseButtonEventArgs e)
     {
         if(e.ButtonState == MouseButtonState.Pressed)
         {
             if(e.Source is System.Windows.Controls.Button || e.Source is Thumb)
-            {
                 return;
-            }
 
             try
             {
@@ -233,20 +226,16 @@ public partial class VolumeKnob : Window, INotifyPropertyChanged
         }
     }
 
-    private void VolumeKnob_MouseWheel(object sender, MouseWheelEventArgs e)
+    void VolumeKnob_MouseWheel(object sender, MouseWheelEventArgs e)
     {
         if(!isWindowInitializationComplete || session == null || !VolumeSlider.IsEnabled)
             return;
 
         float newVolume = Volume;
         if(e.Delta > 0)
-        {
             newVolume += MOUSE_WHEEL_VOLUME_STEP;
-        }
         else if(e.Delta < 0)
-        {
             newVolume -= MOUSE_WHEEL_VOLUME_STEP;
-        }
         Volume = newVolume;
         e.Handled = true;
     }
@@ -343,13 +332,9 @@ public partial class VolumeKnob : Window, INotifyPropertyChanged
             UpdateMuteStateVisuals();
             UpdatePeakMeterTimerState();
             if(session.IsMuted)
-            {
                 Debug.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] MuteButton_Click: Session '{session.DisplayName}' MUTED.");
-            }
             else
-            {
                 Debug.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] MuteButton_Click: Session '{session.DisplayName}' UNMUTED.");
-            }
         }
     }
 
@@ -417,7 +402,7 @@ public partial class VolumeKnob : Window, INotifyPropertyChanged
         }
     }
 
-    private void PeakMeterTimer_Tick(object sender, EventArgs e)
+    void PeakMeterTimer_Tick(object sender, EventArgs e)
     {
         if(session != null)
         {
@@ -448,9 +433,7 @@ public partial class VolumeKnob : Window, INotifyPropertyChanged
             targetPeakForUI = Math.Clamp(targetPeakForUI, 0f, 100f);
 
             if(session.IsMuted)
-            {
                 targetPeakForUI = 0;
-            }
 
             float currentDisplayedPeak = _peakLevel;
             float newSmoothedDisplayValue;

--- a/Windows/VolumeKnob.xaml.cs
+++ b/Windows/VolumeKnob.xaml.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Threading;
 using RightClickVolume.Models;
 
 namespace RightClickVolume;
@@ -19,6 +21,10 @@ public partial class VolumeKnob : Window, INotifyPropertyChanged
     bool isDraggingSlider = false;
     Thumb sliderThumb;
     bool isWindowInitializationComplete = false;
+    const float BasePeakMeterScaleFactor = 150.0f;
+
+    DispatcherTimer peakMeterTimer;
+    float _peakLevel;
 
     static readonly SolidColorBrush BG_Muted = new SolidColorBrush(Color.FromRgb(0x80, 0x30, 0x30));
     static readonly SolidColorBrush FG_Muted = Brushes.White;
@@ -31,6 +37,8 @@ public partial class VolumeKnob : Window, INotifyPropertyChanged
     const string FORMAT_VolumeDisplay = "F0";
     const string IconMuted = "🔇";
     const string IconUnMuted = "🔊";
+    const float PeakMeterScaleFactor = 100.0f;
+    const double PeakCurvePower = 0.75;
 
     public event PropertyChangedEventHandler PropertyChanged;
 
@@ -42,9 +50,7 @@ public partial class VolumeKnob : Window, INotifyPropertyChanged
             if(System.Math.Abs(volume - value) < 0.001f) return;
             volume = value;
             OnPropertyChanged(nameof(Volume));
-
             CurVol = volume.ToString(FORMAT_VolumeDisplay);
-
             if(!isUpdatingFromCode && session != null)
             {
                 if(session.IsMuted)
@@ -79,9 +85,23 @@ public partial class VolumeKnob : Window, INotifyPropertyChanged
         }
     }
 
+    public float PeakLevel
+    {
+        get => _peakLevel;
+        set
+        {
+            if(Math.Abs(_peakLevel - value) > 0.001f)
+            {
+                _peakLevel = value;
+                OnPropertyChanged(nameof(PeakLevel));
+            }
+        }
+    }
+
     public VolumeKnob()
     {
         InitializeComponent();
+        Debug.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] VolumeKnob: Constructor called.");
         isWindowInitializationComplete = false;
         DataContext = this;
 
@@ -90,16 +110,32 @@ public partial class VolumeKnob : Window, INotifyPropertyChanged
         this.Closed += VolumeKnob_Closed;
         this.KeyDown += VolumeKnob_KeyDown;
         this.MouseLeave += VolumeKnob_MouseLeave;
+
+        peakMeterTimer = new DispatcherTimer
+        {
+            Interval = TimeSpan.FromMilliseconds(5)
+        };
+        peakMeterTimer.Tick += PeakMeterTimer_Tick;
+        Debug.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] VolumeKnob: peakMeterTimer Initialized. Interval: {peakMeterTimer.Interval.TotalMilliseconds}ms");
     }
+
+
+
 
     public void ShowAt(double left, double top, AppAudioSession session)
     {
-        if(session == null) throw new ArgumentNullException(nameof(session));
+        Debug.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] VolumeKnob.ShowAt: Method called for session: {(session?.DisplayName ?? "NULL SESSION")}, PID: {(session?.ProcessId.ToString() ?? "N/A")}");
+        if(session == null)
+        {
+            Debug.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] VolumeKnob.ShowAt: Session is NULL. Aborting show and throwing ArgumentNullException.");
+            throw new ArgumentNullException(nameof(session));
+        }
         this.session = session;
 
         isUpdatingFromCode = true;
         AppName = session.DisplayName;
         Volume = session.Volume * VolumeScaleFactor;
+        Debug.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] VolumeKnob.ShowAt: AppName='{AppName}', Initial UI Volume={this.Volume} (Session Vol: {session.Volume:F2})");
         isUpdatingFromCode = false;
 
         UpdateMuteStateVisuals();
@@ -109,22 +145,31 @@ public partial class VolumeKnob : Window, INotifyPropertyChanged
 
         try
         {
+            Debug.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] VolumeKnob.ShowAt: Calling this.Show() and this.Activate()");
             this.Show();
             this.Activate();
+
             Task.Run(async () =>
             {
-                await Task.Delay(TOPMOST_RESET_INITIAL_DELAY);
-                Dispatcher.Invoke(ResetTopmostState);
-                await Task.Delay(TOPMOST_RESET_SECONDARY_DELAY);
-                Dispatcher.Invoke(() =>
-                {
-                    ResetTopmostState();
-                    this.Activate();
-                });
+                await Task.Delay(TOPMOST_RESET_INITIAL_DELAY); Dispatcher.Invoke(ResetTopmostState);
+                await Task.Delay(TOPMOST_RESET_SECONDARY_DELAY); Dispatcher.Invoke(() => { ResetTopmostState(); this.Activate(); });
             });
+
+            if(peakMeterTimer != null)
+            {
+                Debug.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] VolumeKnob.ShowAt: Starting peakMeterTimer. Current PeakLevel (before reset): {PeakLevel:F2}");
+                PeakLevel = 0;
+                peakMeterTimer.Start();
+                Debug.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] VolumeKnob.ShowAt: peakMeterTimer STARTED. IsEnabled: {peakMeterTimer.IsEnabled}");
+            }
+            else
+            {
+                Debug.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] VolumeKnob.ShowAt: peakMeterTimer is NULL! Cannot start.");
+            }
         }
-        catch
+        catch(Exception ex)
         {
+            Debug.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] VolumeKnob.ShowAt: EXCEPTION during Show/Activate or timer start: {ex.Message}");
             try { this.Close(); } catch { }
         }
     }
@@ -137,8 +182,7 @@ public partial class VolumeKnob : Window, INotifyPropertyChanged
 
     void VolumeKnob_KeyDown(object sender, KeyEventArgs e)
     {
-        if(e.Key == Key.Escape)
-            Hide();
+        if(e.Key == Key.Escape) Hide();
     }
 
     void VolumeKnob_MouseLeave(object sender, MouseEventArgs e)
@@ -148,28 +192,35 @@ public partial class VolumeKnob : Window, INotifyPropertyChanged
             {
                 Application.Current?.Dispatcher.Invoke(() =>
                 {
-                    if(this.IsVisible && !this.IsMouseOver && !isDraggingSlider)
-                        Hide();
+                    if(this.IsVisible && !this.IsMouseOver && !isDraggingSlider) Hide();
                 });
             });
     }
 
     void VolumeKnob_Deactivated(object sender, EventArgs e)
     {
-        if(!isDraggingSlider)
-            Hide();
-        else
-            ResetTopmostState();
+        if(!isDraggingSlider) Hide();
+        else ResetTopmostState();
     }
 
     void VolumeKnob_Loaded(object sender, RoutedEventArgs e)
     {
+        Debug.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] VolumeKnob_Loaded: Fired.");
         AttachSliderEvents();
         this.isWindowInitializationComplete = true;
+        Debug.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] VolumeKnob_Loaded: isWindowInitializationComplete = true.");
     }
 
     void VolumeKnob_Closed(object sender, EventArgs e)
     {
+        Debug.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] VolumeKnob_Closed: Fired for App: {this.AppName}");
+        if(peakMeterTimer != null)
+        {
+            Debug.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] VolumeKnob_Closed: Stopping peakMeterTimer. WasEnabled: {peakMeterTimer.IsEnabled}");
+            peakMeterTimer.Stop();
+        }
+        PeakLevel = 0;
+
         this.isWindowInitializationComplete = false;
         DetachSliderEvents();
         session = null;
@@ -178,16 +229,14 @@ public partial class VolumeKnob : Window, INotifyPropertyChanged
         this.Closed -= VolumeKnob_Closed;
         this.KeyDown -= VolumeKnob_KeyDown;
         this.MouseLeave -= VolumeKnob_MouseLeave;
+        Debug.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] VolumeKnob_Closed: Cleanup complete.");
     }
 
     void AttachSliderEvents()
     {
         DetachSliderEvents();
-        if(!VolumeSlider.IsLoaded)
-            VolumeSlider.ApplyTemplate();
-
+        if(!VolumeSlider.IsLoaded) VolumeSlider.ApplyTemplate();
         sliderThumb = FindVisualChild<Thumb>(VolumeSlider);
-
         if(sliderThumb != null)
         {
             sliderThumb.DragStarted += Thumb_DragStarted;
@@ -215,24 +264,10 @@ public partial class VolumeKnob : Window, INotifyPropertyChanged
 
     void VolumeSlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
     {
-        if(!this.isWindowInitializationComplete)
-        {
-            return;
-        }
+        if(!this.isWindowInitializationComplete) return;
 
         if(!isUpdatingFromCode && session != null)
         {
-            float newVolume = (float)e.NewValue / VolumeScaleFactor;
-            if(session.IsMuted)
-            {
-                session.SetMute(!session.IsMuted);
-                UpdateMuteStateVisuals();
-            }
-            session.SetVolume(newVolume);
-
-            isUpdatingFromCode = true;
-            Volume = (float)e.NewValue;
-            isUpdatingFromCode = false;
         }
     }
 
@@ -242,6 +277,15 @@ public partial class VolumeKnob : Window, INotifyPropertyChanged
         {
             session.SetMute(!session.IsMuted);
             UpdateMuteStateVisuals();
+            if(session.IsMuted)
+            {
+                PeakLevel = 0;
+                Debug.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] MuteButton_Click: Session '{session.DisplayName}' MUTED. PeakLevel set to 0.");
+            }
+            else
+            {
+                Debug.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] MuteButton_Click: Session '{session.DisplayName}' UNMUTED.");
+            }
         }
     }
 
@@ -254,19 +298,10 @@ public partial class VolumeKnob : Window, INotifyPropertyChanged
         {
             bool isMuted = session.IsMuted;
             MuteButton.Content = isMuted ? IconMuted : IconUnMuted;
-
-            if(isMuted)
-            {
-                MuteButton.Background = BG_Muted;
-                MuteButton.Foreground = FG_Muted;
-            }
-            else
-            {
-                MuteButton.Background = BG_UnMuted;
-                MuteButton.Foreground = FG_UnMuted;
-            }
-
+            MuteButton.Background = isMuted ? BG_Muted : BG_UnMuted;
+            MuteButton.Foreground = isMuted ? FG_Muted : FG_UnMuted;
             VolumeSlider.IsEnabled = !isMuted;
+            if(PeakVolumeMeter != null) PeakVolumeMeter.IsEnabled = !isMuted;
         }
         catch { }
     }
@@ -284,12 +319,86 @@ public partial class VolumeKnob : Window, INotifyPropertyChanged
         return null;
     }
 
-    protected void OnPropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    protected void OnPropertyChanged(string propertyName)
+    {
+        if(propertyName == nameof(PeakLevel))
+        {
+            Debug.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] OnPropertyChanged Fired for: {propertyName} (New Value: {_peakLevel:F4}) on App: {this.AppName}");
+        }
+        else if(propertyName == nameof(Volume))
+        {
+            Debug.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] OnPropertyChanged Fired for: {propertyName} (New Value: {this.volume:F2}) on App: {this.AppName}");
+        }
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
 
     public new void Hide()
     {
+        Debug.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] VolumeKnob.Hide: Method called for App: {this.AppName}. IsVisible: {this.IsVisible}");
         if(this.IsVisible)
-            try { this.Close(); }
-            catch { }
+        {
+            if(peakMeterTimer != null && peakMeterTimer.IsEnabled)
+            {
+                Debug.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] VolumeKnob.Hide: Stopping peakMeterTimer.");
+                peakMeterTimer.Stop();
+            }
+            PeakLevel = 0;
+            try
+            {
+                Debug.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] VolumeKnob.Hide: Calling this.Close()");
+                this.Close();
+            }
+            catch(Exception ex)
+            {
+                Debug.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] VolumeKnob.Hide: EXCEPTION during this.Close(): {ex.Message}");
+            }
+        }
+    }
+
+    void PeakMeterTimer_Tick(object sender, EventArgs e)
+    {
+        if(session != null && this.IsVisible)
+        {
+            float rawPeak = 0f;
+            try
+            {
+                rawPeak = session.CurrentPeakValue;
+            }
+            catch(Exception ex)
+            {
+                Debug.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] PeakMeterTimer_Tick: ERROR getting session.CurrentPeakValue for '{session.DisplayName}': {ex.Message}");
+                PeakLevel = 0;
+                return;
+            }
+
+            float curvedPeak = (float)Math.Pow(Math.Max(0, rawPeak), PeakCurvePower);
+
+            float scaledPeak = curvedPeak * BasePeakMeterScaleFactor;
+
+            float currentVolumeSettingFactor = this.Volume / 100.0f;
+
+            float finalPeakForUI = scaledPeak * currentVolumeSettingFactor;
+
+            finalPeakForUI = Math.Clamp(finalPeakForUI, 0f, 100f);
+
+
+            if(session.IsMuted)
+            {
+                finalPeakForUI = 0;
+            }
+
+            Debug.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] PeakMeterTick for '{session.DisplayName}': Vis={this.IsVisible}, Muted={session.IsMuted}, RawPeak={rawPeak:F5}, CurvedP={curvedPeak:F5}, ScaledP={scaledPeak:F2}, VolFactor={currentVolumeSettingFactor:F2}, FinalUI={finalPeakForUI:F2}, OldPeakProp={_peakLevel:F2}");
+
+            PeakLevel = finalPeakForUI;
+        }
+        else
+        {
+            string reason = "Unknown";
+            if(session == null) reason = "Session is null";
+            else if(!this.IsVisible) reason = "Window not visible";
+
+            Debug.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] PeakMeterTimer_Tick: Conditions not met ({reason}). Setting PeakLevel to 0.");
+            PeakLevel = 0;
+        }
     }
 }


### PR DESCRIPTION
[Bug Fixes]
Viewing the volume slider for a muted process no longer automatically unmutes on open (It now only mutes and unmutes on explicit press of the mute button)

Startup Exceptions trying to find audio processes on apps with elevated privileges fixed